### PR TITLE
👷 Automate Changelog Generation

### DIFF
--- a/.github/workflows/latest-changes.yaml
+++ b/.github/workflows/latest-changes.yaml
@@ -1,0 +1,27 @@
+name: Latest Changes
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
+  workflow_dispatch:
+    inputs:
+      number:
+        description: PR number
+        required: true
+
+jobs:
+  latest-changes:
+    name: Update Latest Changes in Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tiangolo/latest-changes@0.3.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          latest_changes_file: CHANGELOG.md
+          latest_changes_header: '# Release Notes'
+          end_regex: '^## '
+          label_header_prefix: '### '

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Release Notes
 
-## Latest Changes
-
 ## 0.1.0
 
 * Normalize ED-318 Input during Parsing. PR [#2](https://github.com/starcopter/ed318-pydantic/pull/2) by [@Finwood](https://github.com/Finwood).


### PR DESCRIPTION
This PR integrates the [tiangolo/latest-changes](https://github.com/tiangolo/latest-changes) workflow to automate changelog generation: Pull request titles will automatically be added to the changelog after merging.

This is the way e.g. the [FastAPI release notes](https://github.com/fastapi/fastapi/blob/master/docs/en/docs/release-notes.md) are generated.