### PR TITLE
✨ Translate Authorisation to Authorization

### DIFF
--- a/src/ed318_pydantic/types.py
+++ b/src/ed318_pydantic/types.py
@@ -8,9 +8,9 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
-from .util import Lowercase, Uppercase
+from .util import Lowercase, Translated, Uppercase
 
-CodeAuthorityRole = Uppercase[Literal["AUTHORIZATION", "NOTIFICATION", "INFORMATION"]]
+CodeAuthorityRole = Uppercase[Translated[Literal["AUTHORIZATION", "NOTIFICATION", "INFORMATION"]]]
 """ED-318 4.2.5.1 CodeAuthorityRole
 
 Allowed Values:
@@ -60,7 +60,9 @@ Allowed Values:
   identify it is not the common version which has been transferred.
 """
 
-CodeZoneType = Uppercase[Literal["USPACE", "PROHIBITED", "REQ_AUTHORIZATION", "CONDITIONAL", "NO_RESTRICTION"]]
+CodeZoneType = Uppercase[
+    Translated[Literal["USPACE", "PROHIBITED", "REQ_AUTHORIZATION", "CONDITIONAL", "NO_RESTRICTION"]]
+]
 """ED-318 4.2.5.7 CodeZoneType
 
 Allowed Values:

--- a/src/ed318_pydantic/util.py
+++ b/src/ed318_pydantic/util.py
@@ -37,7 +37,14 @@ def get_list_depth(value: Any) -> int:
     return count
 
 
+def translate_authorisation(value: T) -> T:
+    if not isinstance(value, str):
+        return value
+    return value.replace("AUTHORISATION", "AUTHORIZATION")
+
+
 type Uppercase[T] = Annotated[T, BeforeValidator(to_uppercase)]
 type Lowercase[T] = Annotated[T, BeforeValidator(to_lowercase)]
+type Translated[T] = Annotated[T, BeforeValidator(translate_authorisation)]
 type CoercedOptional[T] = Annotated[T | None, BeforeValidator(empty_str_to_none)]
 type CoercedList[T] = Annotated[list[T], Field(min_length=1), BeforeValidator(convert_to_list)]

--- a/test/test_coercion.py
+++ b/test/test_coercion.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import BaseModel, ValidationError
 
-from ed318_pydantic.types import CodeYesNoType, TextLongType, TextShortType
+from ed318_pydantic.types import CodeAuthorityRole, CodeYesNoType, CodeZoneType, TextLongType, TextShortType
 
 
 def test_text_short_type_from_str():
@@ -47,3 +47,28 @@ def test_code_yes_no_type_from_str():
 
     with pytest.raises(ValidationError):
         MyModel.model_validate({"yes_no": "maybe"})
+
+
+def test_code_zone_type():
+    class MyModel(BaseModel):
+        zone: CodeZoneType
+
+    assert MyModel(zone="USPACE").zone == "USPACE"
+    assert MyModel(zone="Uspace").zone == "USPACE"
+    assert MyModel(zone="uspACe").zone == "USPACE"
+
+    with pytest.raises(ValidationError):
+        MyModel(zone="unknown")
+
+    assert MyModel(zone="REQ_AUTHORIZATION").zone == "REQ_AUTHORIZATION"
+    assert MyModel(zone="REQ_AUTHORISATION").zone == "REQ_AUTHORIZATION", "translation does not work"
+    assert MyModel(zone="req_authorisation").zone == "REQ_AUTHORIZATION", "lowercase translation does not work"
+
+
+def test_authority_role():
+    class MyModel(BaseModel):
+        authority: CodeAuthorityRole
+
+    assert MyModel(authority="AUTHORIZATION").authority == "AUTHORIZATION"
+    assert MyModel(authority="AUTHORISATION").authority == "AUTHORIZATION", "translation does not work"
+    assert MyModel(authority="authorisation").authority == "AUTHORIZATION", "lowercase translation does not work"


### PR DESCRIPTION
Some input data uses "AUTHORISATION" with an s, instead of "AUTHORIZATION" like specified in the standard.